### PR TITLE
RFC - Localizing API (Backend) messages

### DIFF
--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -43,7 +43,7 @@ messages in the API response depending on the language preference set in the req
   * Java, Groovy - properties
   * JavaScript, nodejs - json
   * Any other language - Please contact Technical Council for further guidance
-* Translation files MUST be placed under translations/\<Backend Module Name\>
+* Translation files MUST be placed under translations/\<Backend Module Name\>, relative to the root of the repo
 * Translation file name should be ll_CC.ext. Here ‘ll’ is an ISO 639 two-letter language code, and ‘CC’ is an ISO 3166 two-letter country code.
 * Translation message keys MUST be a string (alphanumeric characters ONLY)
 * Developer should follow language/framework specific recommended best practices for loading translation at runtime

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -3,7 +3,7 @@
 * RFC PR: 
   * https://github.com/folio-org/rfcs/pull/3
 * FOLIO Issue:
-* Current Status: PRELIMINARY REVIEW --> **DRAFT REVIEW** --> PUBLIC REVIEW --> FINAL REVIEW
+* Current Status: :no_entry_sign: DRAFT REVIEW :no_entry_sign:
 * Submitter : Radhakrishnan Gopalakrishnan (rgopalakrishnan@ebsco.com)
 * Co-Submitter(s) : Zak Burke (zburke@ebsco.com)
 * Sub Group : 

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -1,10 +1,14 @@
 
-- Start Date: 2022-03-29
-- RFC PR: 
-- FOLIO Issue: 
-- Submitter : Radhakrishnan Gopalakrishnan (rgopalakrishnan@ebsco.com)
-- Co-Submitter(s) : Zak Burke (zburke@ebsco.com)
-- Sub Group :
+* Start Date: 2022-03-29
+* RFC PR: 
+* FOLIO Issue: 
+* Submitter : Radhakrishnan Gopalakrishnan (rgopalakrishnan@ebsco.com)
+* Co-Submitter(s) : Zak Burke (zburke@ebsco.com)
+* Sub Group : 
+  * Marc Johnson (marc.johnson@k-int.com)
+  * Julian Ladisch (julian.ladisch@gbv.de)
+  * Peter Murray (peter@indexdata.com)
+  * Tod Olson (tod@uchicago.edu)
 
 # Localizing API (Backend) Messages
 
@@ -34,19 +38,18 @@ messages in the API response depending on the language preference set in the req
 - Support for [controlled vocabulary](https://issues.folio.org/browse/UXPROD-3148) (runtime data/data coming from DB tables. E.g. Patron Groups for tenants)
 
 ## Detailed Explanation/Design
-- Locale specific translations MUST be stored in a properties file
-- Properties file naming convention
-  - default locale (en_US) - somename.properties
-  - specific locale - somename_fr.properties (For french),  somename_de.properties (For german)
-- Properties file MUST BE loaded using the classpath. AVOID using file locations
-- Properties file entries WILL use the standard key value pair format
-- When using application frameworks (spring, vertx, etc.) implement localization using the framework specific implementation (if there is one)
-- When handling messages with placeholders, replace the placeholders with the actual value on the server side before
+* Translation file format will depend on the language that is used to develop the module
+  * Java, Groovy - properties
+  * JavaScript, nodejs - json
+* Translation files MUST be placed under translations/<Backend Module Name>
+* Translation message keys MUST be a string (alphanumeric characters ONLY)
+* When handling messages with placeholders, replace the placeholders with the actual value on the server side before
   sending it back to the client
-- STOP using the lang parameter.
-- accept-language header value MUST be in ll_CC format. , where ll is a two-letter language code, 
+* STOP using the lang query string parameter.
+* accept-language header value MUST be in ll_CC format. , where ll is a two-letter language code, 
   and CC is a two-letter country code.
-- When accept-language header is missing or has an incorrect value, return the message in en_US (or the default locale configured)
+* When accept-language header is missing or has an incorrect value, return the message value in en_US. If message value 
+  cannot be found, return the message key
 
 
 ## Rationale and Alternatives
@@ -127,4 +130,7 @@ None that we can think of. The pattern we are adopting is a standard pattern in 
 
 
 ## Unresolved Questions
-- How do we allow tenants to change default locale ?
+- Use of ICU for standardizing messages value format in translation files
+- Tradeoffs 
+- Can the localization project support translating files that are in different formats. 
+  JSON, properties file etc..

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -35,7 +35,7 @@ messages in the API response depending on the language preference set in the req
 - Returning formatted (HTML/Markdown) messages
 - Usage of [soft hyphen](https://wiki.folio.org/display/I18N/How+To+translate+FOLIO#HowTotranslateFOLIO-Softhyphentobreakwords) to break messages
 - Support customization per tenant
-- Process for back porting API/Backend messages similar to what we have for the front end 
+- Process  for [back porting](https://wiki.folio.org/display/I18N/Backport) API/Backend messages similar to what we have for the front end 
 - Support for controlled vocabulary (runtime data/data coming from DB tables. E.g. Patron Groups for tenants)
 
 ## Detailed Explanation/Design

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -23,13 +23,21 @@
 - Backport
 
 ### In Scope Requirements/Use cases
-- Return localized messages (error/informational/validation) based on the value passed in the accept-language header
+- Return localized messages based on the value passed in the accept-language header
+- Handle
+  - application error messages
+  - validation messages
+  - informational messages
+  - system error messages
+  - Messages with dynamic content. For E.g Loan CANNOT be renewed more than {n} times
+  - 
 - Support for controlled vocabulary
 - Support for customizing translations per tenant
 - Process for backporting API/Backend messages similar to what we have for the front end 
 - Define naming convention to be used for keys
 - Define process for managing (decoupled from lokalise.com) translations
 - Return messages in en_US if the accept-language is empty/not supported/invalid
+- [Plural Syntax](https://wiki.folio.org/display/I18N/How+To+translate+FOLIO#HowTotranslateFOLIO-Pluralsyntax)
 
 ### Out of Scope Requirements/Use cases
 - Returning formatted (HTML/Markdown) messages
@@ -112,4 +120,5 @@ When calling the back-end pass the required locale. The back-end maintains the t
 *Cons*
 
 ## Unresolved Questions
-- None
+- Usage of [soft hyphen](https://wiki.folio.org/display/I18N/How+To+translate+FOLIO#HowTotranslateFOLIO-Softhyphentobreakwords) 
+  to break messages. Is it in scope ?

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -1,0 +1,53 @@
+
+- Start Date: 03-29-2022
+- RFC PR: 
+- FOLIO Issue: 
+
+# Localizing API (Backend) Messages
+
+## Summary
+
+One paragraph description of feature.
+
+## Motivation
+
+Why are we doing this? What use cases does it support? What is the expected outcome? What is the strategic value?
+
+## Detailed Explanation/Design
+
+This is the bulk of the RFC. 
+
+Explain the proposal as though it were already implemented and you were teaching it to someone already familiar with Folio - foregoing unnecessary introductory material.
+
+* Get into the specifics including corner cases and plenty of examples.
+* Define any new terminology and named concepts
+* Fully explain the scope of the proposal: backend; frontend; full-stack.
+* Provide clear guidance as to how the proposal might be implemented.
+* Include any reference to any existing Folio Jira issues.
+* If appropriate, the use of diagrams and illustrations is encouraged.
+* Provide any assessment of the dependency impact of the proposed change; its interaction with other features is clear.
+* If possible describe how disruptive the change might be to the existing Folio development community.
+* Discuss how any breaking changes can be rolled out (migration guidance).
+* If applicable, provide sample code or pseudo-code,  error messages, or deprecation warnings
+* Describe the impact on existing Folio documentation, guides and other reference materials.
+
+## Risks and Drawbacks
+
+Why should we not do this? 
+
+A genuine and thoughtful consideration to risks and drawbacks is essential for a well-rounded proposal. 
+
+## Rationale and Alternatives
+
+Why is this design the best in the space of possible designs? How does this design integrate (or not) into the existing architecture and practices in Folio?
+
+
+What other designs have been considered and what is the rationale for not choosing them? 
+
+This section could also include prior art, that is, how other the same problem may have already been solved elsewhere.
+
+## Unresolved Questions
+
+Optional, but suggested for first drafts. What parts of the design are still TBD?
+
+What related issues do you consider out of scope for this RFC that could be addressed in the future independently of the solution that comes out of this RFC?

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -60,7 +60,7 @@ messages in the API response depending on the language preference set in the req
   MUST return the message in the en language.
 * When handling messages with placeholders, replace the placeholders with the actual value on the server side before
     sending it back to the client
-* Reliance on the lang query string parameter is DEPRECATED and SHOULD be updated to use the "Accept-language" header
+* Reliance on the lang query string parameter is DEPRECATED and MUST be updated to use the "Accept-language" header
   at the earliest possible development sprint.
 
 #### Translation files
@@ -79,7 +79,7 @@ messages in the API response depending on the language preference set in the req
 * Translation message keys MUST be a valid string 
 * Message Values in the translation file MUST be formatted according to the [ICU](https://icu.unicode.org)  standard
 #### Language/Runtime
-* Module SHOULD use language/framework specific recommended best practices for loading translation at runtime
+* Module MUST use language/framework specific recommended best practices for loading translation at runtime
 
 
 

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -34,7 +34,7 @@ messages in the API response depending on the language preference set in the req
 * Message Key - Refers to the string that is used in place of a hardcoded message in the code
 * Message Value - Refers to the string that is fetched using a message key lookup for a given locale
 * Translation file - Contains Message key and values for a given locale
-* Static Messages - Refers to the messages values stored in the translation file
+* Static (design / compile time) Messages - Message values that are defined during development and do not vary by deployment environment
 * Dynamic Messages - Messages stored in the database that requires translation. A.k.a Runtime messages
 * Message Format - Refers to the standard used for formatting the message values in the translation file
 

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -157,7 +157,7 @@ When calling the back-end pass the required locale. The back-end maintains the t
 
 ## Risks and Drawbacks
 
-None that we can think of. The pattern we are adopting is a standard pattern in the java community
+- Translation files are spread over multiple repositories
 
 
 ## Unresolved Questions

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -44,7 +44,6 @@ messages in the API response depending on the language preference set in the req
 - Handle static messages with placeholder(s)
 
 ### Out of Scope Requirements/Use cases
-- [Plural Syntax](https://wiki.folio.org/display/I18N/How+To+translate+FOLIO#HowTotranslateFOLIO-Pluralsyntax)
 - Naming convention to be used for keys
 - Process for managing (decoupled from lokalise.com) translations
 - Returning formatted (HTML/Markdown) messages
@@ -71,6 +70,7 @@ messages in the API response depending on the language preference set in the req
 * A module MUST return messages in the language specified in the HTTP "Accept-language" request header
   (see IETF RFC 7231 section 5.3.5).  If the requested language is not available, a module 
   MUST return the message in the en language.
+* Message Values in the translation file MUST be formatted according to the [ICU](https://icu.unicode.org)  standard 
 
 
 ## Rationale and Alternatives

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -1,7 +1,9 @@
 
 * Start Date: 2022-03-29
 * RFC PR: 
-* FOLIO Issue: 
+  * https://github.com/folio-org/rfcs/pull/3
+* FOLIO Issue:
+* Current Status: PRELIMINARY REVIEW --> **DRAFT REVIEW** --> PUBLIC REVIEW --> FINAL REVIEW
 * Submitter : Radhakrishnan Gopalakrishnan (rgopalakrishnan@ebsco.com)
 * Co-Submitter(s) : Zak Burke (zburke@ebsco.com)
 * Sub Group : 

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -17,6 +17,15 @@ messages in the API response depending on the language preference set in the req
 - To create a tremendous opportunity for growth that we can never could have achieved within just one country.
 
 ## Detailed Explanation/Design
+- Locale specific translations MUST be stored in a properties file
+- Properties file naming convention 
+  - default locale (en_US) - somename.properties
+  - specific locale - somename_fr.properties (For french),  somename_de.properties (For german)
+- Properties file MUST BE loaded using the classpath. AVOID using file locations
+- Properties file entries WILL use the standard key value pair format
+- When using application frameworks (spring, vertx, etc.) implement localization using the framework specific implementation (if there is one)
+- When handling messages with placeholders, replace the placeholders with the actual value on the server side before 
+  sending it back to the client
 
 ### Terminology
 - Static Message - E.g. _This is something you need translate_
@@ -122,3 +131,4 @@ When calling the back-end pass the required locale. The back-end maintains the t
 *Cons*
 
 ## Unresolved Questions
+- How do we allow tenants to change default locale ?

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -19,8 +19,8 @@ messages in the API response depending on the language preference set in the req
 ## Detailed Explanation/Design
 
 ### Terminology
-- Static Message - This is something you need translate
-- Static Message with placeholder - You can ONLY renew {n} times
+- Static Message - E.g. _This is something you need translate_
+- Static Message with placeholder - _You can ONLY renew {n} times_
  
 
 ### In Scope Requirements/Use cases

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -12,8 +12,7 @@ messages in the API response depending on the language preference set in the req
 
 ## Motivation
 
-- Help users understand the information coming from the application backend as they can relate to it  better when it is
-    in a language they understand
+- Help users understand the information coming from the application backend using a language they understand better
 - To allow FOLIO platform to be used by users across the world 
 - To create a tremendous opportunity for growth that we can never could have achieved within just one country.
 
@@ -42,6 +41,8 @@ messages in the API response depending on the language preference set in the req
 
 ### Out of Scope Requirements/Use cases
 - Returning formatted (HTML/Markdown) messages
+- Usage of [soft hyphen](https://wiki.folio.org/display/I18N/How+To+translate+FOLIO#HowTotranslateFOLIO-Softhyphentobreakwords)to break messages
+
 
 ### Design Notes
 - STOP using the lang parameter.
@@ -121,5 +122,3 @@ When calling the back-end pass the required locale. The back-end maintains the t
 *Cons*
 
 ## Unresolved Questions
-- Usage of [soft hyphen](https://wiki.folio.org/display/I18N/How+To+translate+FOLIO#HowTotranslateFOLIO-Softhyphentobreakwords) 
-  to break messages. Is it in scope ?

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -25,11 +25,12 @@ messages in the API response depending on the language preference set in the req
 
 ### In Scope Requirements/Use cases
 - Return localized messages based on the value passed in the accept-language header
-- Handle
-  - application error messages
-  - validation messages
-  - informational messages
-  - system error messages
+- Handle static messages and static messages with placeholders
+- Message categories
+  - application
+  - validation
+  - informational
+  - system error
 - Define naming convention to be used for keys
 - [Plural Syntax](https://wiki.folio.org/display/I18N/How+To+translate+FOLIO#HowTotranslateFOLIO-Pluralsyntax)
 - Runtime values that are to be localized (E.g. Patron Groups) 

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -2,7 +2,7 @@
 * Start Date: 2022-03-29
 * RFC PR: 
   * Preliminary Review: https://github.com/folio-org/rfcs/pull/3
-  * Draft Review :
+  * Draft Review : https://github.com/folio-org/rfcs/pull/3
   * Public Review :
   * Final Review :
 * FOLIO Issue:

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -19,14 +19,9 @@ messages in the API response depending on the language preference set in the req
 - To allow FOLIO platform to be used by users across the world 
 - To create a tremendous opportunity for growth that we can never could have achieved within just one country.
 
-### Terminology
-- Static Message - E.g. _This is something you need translate_
-- Static Message with placeholder - _You can ONLY renew {n} times_
- 
-
 ### In Scope Requirements/Use cases
 - Return localized messages based on the value passed in the accept-language header
-- Handle static messages, static messages with placeholders
+- Handle static messages with placeholder(s)
 
 ### Out of Scope Requirements/Use cases
 - [Plural Syntax](https://wiki.folio.org/display/I18N/How+To+translate+FOLIO#HowTotranslateFOLIO-Pluralsyntax)

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -51,7 +51,7 @@ messages in the API response depending on the language preference set in the req
 - STOP using the lang parameter.
 - accept-language header value MUST be in ll_CC format. , where ll is a two-letter language code, 
   and CC is a two-letter country code.
-- When accept-language header is missing or has an incorrect value, return the message in en_US
+- When accept-language header is missing or has an incorrect value, return the message in en_US (or the default locale configured)
 
 ## Risks and Drawbacks
 

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -18,12 +18,18 @@
 
 ## Detailed Explanation/Design
 
+### Terminology
+- Controlled Vocabulary
+- Backport
+
 ### In Scope Requirements/Use cases
 - Return localized messages (error/informational/validation) based on the value passed in the accept-language header
-- Controlled Vocabulary
+- Support for controlled vocabulary
+- Support for customizing translations per tenant
 - Process for backporting API/Backend messages similar to what we have for the front end 
 - Define naming convention to be used for keys
 - Define process for managing (decoupled from lokalise.com) translations
+- Return messages in en_US if the accept-language is empty/not supported/invalid
 
 ### Out of Scope Requirements/Use cases
 - Returning formatted (HTML/Markdown) messages

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -6,7 +6,7 @@
   * Public Review : https://github.com/folio-org/rfcs/pull/3
   * Final Review : https://github.com/folio-org/rfcs/pull/3
 * FOLIO Issue:
-* Current Status: :no_entry_sign: FINAL REVIEW :no_entry_sign:
+* Current Status: :no_entry_sign: ACCEPTED :no_entry_sign:
 * Submitter : Radhakrishnan Gopalakrishnan (rgopalakrishnan@ebsco.com)
 * Co-Submitter(s) : Zak Burke (zburke@ebsco.com)
 * Sub Group : 

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -71,7 +71,7 @@ messages in the API response depending on the language preference set in the req
 * Translation files MUST be placed under translations/\<Backend Module Name\>, relative to the root of the repo.
   The files are being stored under a folder named after the module/repo to avoid having conflicts when using the same
   message key across multiple backend modules. 
-* Translation file name MUST be [language code]_[country code].[extension] 
+* Translation file name MUST be [language code]-[country code].[extension] 
   where `language code` is an ISO 639 two-letter language code, `country code` is an ISO 3166 two-letter country code 
   and `extension` is the appropriate extension for the file format. For example, in `ll-CC.json`, 
   ‘ll’ is the language code, ‘CC’ country code and `json` is the extension

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -77,7 +77,7 @@ messages in the API response depending on the language preference set in the req
   and `extension` is the appropriate extension for the file format.
 #### Translations
 * Translation message keys MUST be a valid string 
-* Message Values in the translation file MUST be formatted according to the [ICU](https://icu.unicode.org)  standard
+* Message values in the translation file MUST be formatted according to the [ICU](https://icu.unicode.org)  standard
 #### Language/Runtime
 * Module MUST use language/framework specific recommended best practices for loading translation at runtime
 

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -16,8 +16,19 @@ Why are we doing this? What use cases does it support? What is the expected outc
 ## Detailed Explanation/Design
 
 ### In Scope Requirements/Use cases
+- Return localized messages (error/informational/validation) based on the value passed in the accept-language header
+- Controlled Vocabulary
+- Process for backporting API/Backend messages similar to what we have for the front end 
+- Define naming convention to be used for keys
+- Define process for managing (decoupled from lokalise.com) translations
 
 ### Out of Scope Requirements/Use cases
+- Returning formatted (HTML/Markdown) messages
+
+### Design Notes
+- STOP using the lang parameter.
+- accept-language header value MUST be in ll_CC format. , where ll is a two-letter language code, 
+  and CC is a two-letter country code.
 
 ## Risks and Drawbacks
 
@@ -92,7 +103,4 @@ When calling the back-end pass the required locale. The back-end maintains the t
 *Cons*
 
 ## Unresolved Questions
-
-Optional, but suggested for first drafts. What parts of the design are still TBD?
-
-What related issues do you consider out of scope for this RFC that could be addressed in the future independently of the solution that comes out of this RFC?
+- None

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -3,10 +3,10 @@
 * RFC PR: 
   * Preliminary Review: https://github.com/folio-org/rfcs/pull/3
   * Draft Review : https://github.com/folio-org/rfcs/pull/3
-  * Public Review :
-  * Final Review :
+  * Public Review : https://github.com/folio-org/rfcs/pull/3
+  * Final Review : https://github.com/folio-org/rfcs/pull/3
 * FOLIO Issue:
-* Current Status: :no_entry_sign: DRAFT REVIEW :no_entry_sign:
+* Current Status: :no_entry_sign: FINAL REVIEW :no_entry_sign:
 * Submitter : Radhakrishnan Gopalakrishnan (rgopalakrishnan@ebsco.com)
 * Co-Submitter(s) : Zak Burke (zburke@ebsco.com)
 * Sub Group : 

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -157,3 +157,5 @@ None that we can think of. The pattern we are adopting is a standard pattern in 
 - Can the localization project support translating files that are in different formats. 
   JSON, properties file etc.
 - Terminology Section 
+- Using - vs. _ in the translation file name
+- Translation file location

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -124,12 +124,11 @@ When calling the back-end pass the required locale. The back-end maintains the t
 - This is a well known pattern in the Java community
 
 *Cons*
+- None
 
 ## Risks and Drawbacks
 
-Why should we not do this? 
-
-A genuine and thoughtful consideration to risks and drawbacks is essential for a well-rounded proposal. 
+None that we can think of. The pattern we are adopting is a standard pattern in the java community
 
 
 ## Unresolved Questions

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -143,8 +143,9 @@ None that we can think of. The pattern we are adopting is a standard pattern in 
 
 
 ## Unresolved Questions
-- Use of ICU for standardizing messages value format in translation files
+- Use of ICU for standardizing messages value format in translation files. Impact analysis if were not 
+  to adopt ICU standard
 - Tradeoffs 
 - Can the localization project support translating files that are in different formats. 
-  JSON, properties file etc..
+  JSON, properties file etc.
 - Terminology Section 

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -53,7 +53,7 @@ messages in the API response depending on the language preference set in the req
 
 ## Detailed Explanation/Design
 #### API Protocol
-* accept-language header value MUST be in ll_CC format. , where ll is a two-letter language code,
+* accept-language header value MUST be in ll-CC format. , where ll is a two-letter language code,
   and CC is a two-letter country code.
 * A module MUST return messages in the language specified in the HTTP "Accept-language" request header
   (see IETF RFC 7231 section 5.3.5).  If the requested language is not available, a module

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -33,7 +33,7 @@ messages in the API response depending on the language preference set in the req
 - Naming convention to be used for keys
 - Process for managing (decoupled from lokalise.com) translations
 - Returning formatted (HTML/Markdown) messages
-- Usage of [soft hyphen](https://wiki.folio.org/display/I18N/How+To+translate+FOLIO#HowTotranslateFOLIO-Softhyphentobreakwords)to break messages
+- Usage of [soft hyphen](https://wiki.folio.org/display/I18N/How+To+translate+FOLIO#HowTotranslateFOLIO-Softhyphentobreakwords) to break messages
 - Support customization per tenant
 - Process for back porting API/Backend messages similar to what we have for the front end 
 - Support for controlled vocabulary (runtime data/data coming from DB tables. E.g. Patron Groups for tenants)

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -41,7 +41,8 @@ messages in the API response depending on the language preference set in the req
 * Translation file format will depend on the language that is used to develop the module
   * Java, Groovy - properties
   * JavaScript, nodejs - json
-* Translation files MUST be placed under translations/<Backend Module Name>
+  * Any other language - Please contact Technical Council for further guidance
+* Translation files MUST be placed under translations/\<Backend Module Name\>
 * Translation message keys MUST be a string (alphanumeric characters ONLY)
 * When handling messages with placeholders, replace the placeholders with the actual value on the server side before
   sending it back to the client

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -15,21 +15,9 @@ Why are we doing this? What use cases does it support? What is the expected outc
 
 ## Detailed Explanation/Design
 
-This is the bulk of the RFC. 
+### In Scope Requirements/Use cases
 
-Explain the proposal as though it were already implemented and you were teaching it to someone already familiar with Folio - foregoing unnecessary introductory material.
-
-* Get into the specifics including corner cases and plenty of examples.
-* Define any new terminology and named concepts
-* Fully explain the scope of the proposal: backend; frontend; full-stack.
-* Provide clear guidance as to how the proposal might be implemented.
-* Include any reference to any existing Folio Jira issues.
-* If appropriate, the use of diagrams and illustrations is encouraged.
-* Provide any assessment of the dependency impact of the proposed change; its interaction with other features is clear.
-* If possible describe how disruptive the change might be to the existing Folio development community.
-* Discuss how any breaking changes can be rolled out (migration guidance).
-* If applicable, provide sample code or pseudo-code,  error messages, or deprecation warnings
-* Describe the impact on existing Folio documentation, guides and other reference materials.
+### Out of Scope Requirements/Use cases
 
 ## Risks and Drawbacks
 
@@ -39,7 +27,9 @@ A genuine and thoughtful consideration to risks and drawbacks is essential for a
 
 ## Rationale and Alternatives
 
-Following options were considered
+Following options were considered. All options except Option 4 involves stripes in some manner.
+Coupling the API backend to a specific front end framework severely limits the usage of FOLIO API to
+only clients that are built using Stripes. 
 
 ### Option 1
 Distribute them over the existing front-end modules:
@@ -47,10 +37,10 @@ Distribute them over the existing front-end modules:
 ui-checkin with translation key ui-checkin.mod-circulation.itemNotFound
 ui-requests with translation key ui-requests.mod-circulation.patronHasItemOnLoad
 
-####Pros
+*Pros*
 - Uses existing front-end modules
 
-####Cons
+*Cons*
 - Cannot disable a front-end module for a tenant if it hosts a mod-circulation translation key that is needed by another enabled front-end module.
 
 ### Option 2a
@@ -61,10 +51,10 @@ For example create ui-mod-circulation module, and use translation keys
 ui-mod-circulation.itemNotFound
 ui-mod-circulation.patronHasItemOnLoad
 
-####Pros
+*Pros*
 - Any front-end module that uses mod-circulation can require ui-mod-circulation to load the translation files.
 - All mod-circulation translation strings go into a single module.
-####Cons
+*Cons*
 
 
 ### Option 2b
@@ -75,10 +65,10 @@ For example create i18n-circulation module, and use translation keys
 i18n-circulation.itemNotFound
 i18n-circulation.patronHasItemOnLoad
 
-####Pros
+*Pros*
 - Any front-end module that uses the circulation API can require i18n-circulation to load the translation files.
 - All circulation translation strings go into a single module.
-####Cons
+*Cons*
 
 ### Option 3
 The back-end module hosts the language files.
@@ -87,18 +77,19 @@ mod-circulation creates a translations/mod-circulation/ directory.
 
 Stripes fetches the translation files from the back-end module and can process them the same way as translation files from frone-end modules.
 
-####Pros
+*Pros*
 - Software and language files are in the same repository. Options 1 and 2 require to add the message string to some other repository using a second pull request.
 
-####Cons
+*Cons*
 - Is this technically feasible? How can Stripes fetch languages files from a non-Stripes module?
 
 ### Option 4:
 When calling the back-end pass the required locale. The back-end maintains the translations files, replaces the placeholders and puts the final string into the "message" property. A lang query parameter that many FOLIO API interfaces already have or an "accept-language" header line might be used.
 
-####Pros
+*Pros*
 - Java code and translation files live in the same repository. No work for the front-end.
 
+*Cons*
 
 ## Unresolved Questions
 

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -2,6 +2,9 @@
 - Start Date: 03-29-2022
 - RFC PR: 
 - FOLIO Issue: 
+- Submitter : Radhakrishnan Gopalakrishnan (rgopalakrishnan@ebsco.com)
+- Co-Submitter(s) : Zak Burke (zburke@ebsco.com)
+- Sub Group :
 
 # Localizing API (Backend) Messages
 

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -18,7 +18,7 @@
 # Localizing API (Backend) Messages
 
 ## Summary
-  The purpose of this RFC is to define an approach that allows API developer to provide
+The purpose of this RFC is to define an approach that allows API developer to provide
 messages in the API response depending on the language preference set in the request. 
 
 

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -31,6 +31,7 @@ messages in the API response depending on the language preference set in the req
 
 ### Terminology
 * Controlled Vocabulary - ???
+* Base Language - Language on which all other translations are based.
 * Message Key - Refers to the string that is used in place of a hardcoded message in the code
 * Message Value - Refers to the string that is fetched using a message key lookup for a given locale
 * Translation file - Contains Message key and values for a given locale
@@ -63,11 +64,13 @@ messages in the API response depending on the language preference set in the req
 * Developer should follow language/framework specific recommended best practices for loading translation at runtime
 * When handling messages with placeholders, replace the placeholders with the actual value on the server side before
   sending it back to the client
-* STOP using the lang query string parameter.
+* Reliance on the lang query string parameter is DEPRECATED and SHOULD be updated to use the "Accept-language" header 
+  at the earliest possible development sprint.
 * accept-language header value MUST be in ll_CC format. , where ll is a two-letter language code, 
   and CC is a two-letter country code.
-* When accept-language header is missing or has an incorrect value, return the message value in en_US. If message value 
-  cannot be found, return the message key
+* A module MUST return messages in the language specified in the HTTP "Accept-language" request header
+  (see IETF RFC 7231 section 5.3.5).  If the requested language is not available, a module 
+  MUST return the message in the en language.
 
 
 ## Rationale and Alternatives

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -45,8 +45,6 @@ messages in the API response depending on the language preference set in the req
 - When using application frameworks (spring, vertx, etc.) implement localization using the framework specific implementation (if there is one)
 - When handling messages with placeholders, replace the placeholders with the actual value on the server side before
   sending it back to the client
-
-### Design Notes
 - STOP using the lang parameter.
 - accept-language header value MUST be in ll_CC format. , where ll is a two-letter language code, 
   and CC is a two-letter country code.

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -43,7 +43,9 @@ messages in the API response depending on the language preference set in the req
   * JavaScript, nodejs - json
   * Any other language - Please contact Technical Council for further guidance
 * Translation files MUST be placed under translations/\<Backend Module Name\>
+* Translation file name should be ll_CC.ext. Here ‘ll’ is an ISO 639 two-letter language code, and ‘CC’ is an ISO 3166 two-letter country code.
 * Translation message keys MUST be a string (alphanumeric characters ONLY)
+* Developer should follow language/framework specific recommended best practices for loading translation at runtime
 * When handling messages with placeholders, replace the placeholders with the actual value on the server side before
   sending it back to the client
 * STOP using the lang query string parameter.

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -54,7 +54,8 @@ messages in the API response depending on the language preference set in the req
 ## Detailed Explanation/Design
 #### API Protocol
 * accept-language header value MUST be in ll-CC format. , where ll is a two-letter language code,
-  and CC is a two-letter country code.
+  and CC is a two-letter country code. Refer to [IETF Language Tag standard](https://en.wikipedia.org/wiki/IETF_language_tag)
+  for additional details
 * A module MUST return messages in the language specified in the HTTP "Accept-language" request header
   (see IETF RFC 7231 section 5.3.5).  If the requested language is not available, a module
   MUST return the message in the en language.
@@ -71,10 +72,9 @@ messages in the API response depending on the language preference set in the req
 * Translation files MUST be placed under translations/\<Backend Module Name\>, relative to the root of the repo.
   The files are being stored under a folder named after the module/repo to avoid having conflicts when using the same
   message key across multiple backend modules. 
-* Translation file name MUST be [language code]-[country code].[extension] 
-  where `language code` is an ISO 639 two-letter language code, `country code` is an ISO 3166 two-letter country code 
-  and `extension` is the appropriate extension for the file format. For example, in `ll-CC.json`, 
-  ‘ll’ is the language code, ‘CC’ country code and `json` is the extension
+* Translation file name MUST be named [language code]-[country code].[extension] 
+  The language code and country code MUST adhere to  [IETF Language Tag standard](https://en.wikipedia.org/wiki/IETF_language_tag)  
+  and `extension` is the appropriate extension for the file format.
 #### Translations
 * Translation message keys MUST be a valid string 
 * Message Values in the translation file MUST be formatted according to the [ICU](https://icu.unicode.org)  standard

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -26,28 +26,23 @@ messages in the API response depending on the language preference set in the req
 ### In Scope Requirements/Use cases
 - Return localized messages based on the value passed in the accept-language header
 - Handle static messages and static messages with placeholders
-- Message categories
-  - application
-  - validation
-  - informational
-  - system error
-- Define naming convention to be used for keys
-- [Plural Syntax](https://wiki.folio.org/display/I18N/How+To+translate+FOLIO#HowTotranslateFOLIO-Pluralsyntax)
-- Runtime values that are to be localized (E.g. Patron Groups) 
 
 ### Out of Scope Requirements/Use cases
+- [Plural Syntax](https://wiki.folio.org/display/I18N/How+To+translate+FOLIO#HowTotranslateFOLIO-Pluralsyntax)
+- Naming convention to be used for keys
 - Process for managing (decoupled from lokalise.com) translations
 - Returning formatted (HTML/Markdown) messages
 - Usage of [soft hyphen](https://wiki.folio.org/display/I18N/How+To+translate+FOLIO#HowTotranslateFOLIO-Softhyphentobreakwords)to break messages
 - Support customization per tenant
 - Process for backporting API/Backend messages similar to what we have for the front end 
-- Support for controlled vocabulary (runtime data/)
+- Support for controlled vocabulary (runtime data/data coming from DB tables. E.g. Patron Groups for tenants)
 
 
 ### Design Notes
 - STOP using the lang parameter.
 - accept-language header value MUST be in ll_CC format. , where ll is a two-letter language code, 
   and CC is a two-letter country code.
+- When accept-language header is missing or has an incorrect value, return the message in en_US
 
 ## Risks and Drawbacks
 

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -7,7 +7,7 @@
 
 ## Summary
 
-One paragraph description of feature.
+
 
 ## Motivation
 
@@ -39,12 +39,66 @@ A genuine and thoughtful consideration to risks and drawbacks is essential for a
 
 ## Rationale and Alternatives
 
-Why is this design the best in the space of possible designs? How does this design integrate (or not) into the existing architecture and practices in Folio?
+Following options were considered
+
+### Option 1
+Distribute them over the existing front-end modules:
+
+ui-checkin with translation key ui-checkin.mod-circulation.itemNotFound
+ui-requests with translation key ui-requests.mod-circulation.patronHasItemOnLoad
+
+####Pros
+- Uses existing front-end modules
+
+####Cons
+- Cannot disable a front-end module for a tenant if it hosts a mod-circulation translation key that is needed by another enabled front-end module.
+
+### Option 2a
+For each back-end module with translation keys create a dedicated front-end module with language files:
+
+For example create ui-mod-circulation module, and use translation keys
+
+ui-mod-circulation.itemNotFound
+ui-mod-circulation.patronHasItemOnLoad
+
+####Pros
+- Any front-end module that uses mod-circulation can require ui-mod-circulation to load the translation files.
+- All mod-circulation translation strings go into a single module.
+####Cons
 
 
-What other designs have been considered and what is the rationale for not choosing them? 
+### Option 2b
+For each back-end interface with translation keys create a dedicated front-end module with language files:
 
-This section could also include prior art, that is, how other the same problem may have already been solved elsewhere.
+For example create i18n-circulation module, and use translation keys
+
+i18n-circulation.itemNotFound
+i18n-circulation.patronHasItemOnLoad
+
+####Pros
+- Any front-end module that uses the circulation API can require i18n-circulation to load the translation files.
+- All circulation translation strings go into a single module.
+####Cons
+
+### Option 3
+The back-end module hosts the language files.
+
+mod-circulation creates a translations/mod-circulation/ directory.
+
+Stripes fetches the translation files from the back-end module and can process them the same way as translation files from frone-end modules.
+
+####Pros
+- Software and language files are in the same repository. Options 1 and 2 require to add the message string to some other repository using a second pull request.
+
+####Cons
+- Is this technically feasible? How can Stripes fetch languages files from a non-Stripes module?
+
+### Option 4:
+When calling the back-end pass the required locale. The back-end maintains the translations files, replaces the placeholders and puts the final string into the "message" property. A lang query parameter that many FOLIO API interfaces already have or an "accept-language" header line might be used.
+
+####Pros
+- Java code and translation files live in the same repository. No work for the front-end.
+
 
 ## Unresolved Questions
 

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -16,17 +16,6 @@ messages in the API response depending on the language preference set in the req
 - To allow FOLIO platform to be used by users across the world 
 - To create a tremendous opportunity for growth that we can never could have achieved within just one country.
 
-## Detailed Explanation/Design
-- Locale specific translations MUST be stored in a properties file
-- Properties file naming convention 
-  - default locale (en_US) - somename.properties
-  - specific locale - somename_fr.properties (For french),  somename_de.properties (For german)
-- Properties file MUST BE loaded using the classpath. AVOID using file locations
-- Properties file entries WILL use the standard key value pair format
-- When using application frameworks (spring, vertx, etc.) implement localization using the framework specific implementation (if there is one)
-- When handling messages with placeholders, replace the placeholders with the actual value on the server side before 
-  sending it back to the client
-
 ### Terminology
 - Static Message - E.g. _This is something you need translate_
 - Static Message with placeholder - _You can ONLY renew {n} times_
@@ -34,7 +23,7 @@ messages in the API response depending on the language preference set in the req
 
 ### In Scope Requirements/Use cases
 - Return localized messages based on the value passed in the accept-language header
-- Handle static messages, static messages with placeholders and JSON error response
+- Handle static messages, static messages with placeholders
 
 ### Out of Scope Requirements/Use cases
 - [Plural Syntax](https://wiki.folio.org/display/I18N/How+To+translate+FOLIO#HowTotranslateFOLIO-Pluralsyntax)
@@ -43,9 +32,19 @@ messages in the API response depending on the language preference set in the req
 - Returning formatted (HTML/Markdown) messages
 - Usage of [soft hyphen](https://wiki.folio.org/display/I18N/How+To+translate+FOLIO#HowTotranslateFOLIO-Softhyphentobreakwords)to break messages
 - Support customization per tenant
-- Process for backporting API/Backend messages similar to what we have for the front end 
+- Process for back porting API/Backend messages similar to what we have for the front end 
 - Support for controlled vocabulary (runtime data/data coming from DB tables. E.g. Patron Groups for tenants)
 
+## Detailed Explanation/Design
+- Locale specific translations MUST be stored in a properties file
+- Properties file naming convention
+  - default locale (en_US) - somename.properties
+  - specific locale - somename_fr.properties (For french),  somename_de.properties (For german)
+- Properties file MUST BE loaded using the classpath. AVOID using file locations
+- Properties file entries WILL use the standard key value pair format
+- When using application frameworks (spring, vertx, etc.) implement localization using the framework specific implementation (if there is one)
+- When handling messages with placeholders, replace the placeholders with the actual value on the server side before
+  sending it back to the client
 
 ### Design Notes
 - STOP using the lang parameter.

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -30,18 +30,16 @@ messages in the API response depending on the language preference set in the req
   - informational messages
   - system error messages
   - Messages with dynamic content. For E.g Loan CANNOT be renewed more than {n} times
-  - 
-- Support for controlled vocabulary
-- Support for customizing translations per tenant
-- Process for backporting API/Backend messages similar to what we have for the front end 
 - Define naming convention to be used for keys
-- Define process for managing (decoupled from lokalise.com) translations
-- Return messages in en_US if the accept-language is empty/not supported/invalid
 - [Plural Syntax](https://wiki.folio.org/display/I18N/How+To+translate+FOLIO#HowTotranslateFOLIO-Pluralsyntax)
 
 ### Out of Scope Requirements/Use cases
+- Process for managing (decoupled from lokalise.com) translations
 - Returning formatted (HTML/Markdown) messages
 - Usage of [soft hyphen](https://wiki.folio.org/display/I18N/How+To+translate+FOLIO#HowTotranslateFOLIO-Softhyphentobreakwords)to break messages
+- Support customization per tenant
+- Process for backporting API/Backend messages similar to what we have for the front end 
+- Support for controlled vocabulary (runtime data/)
 
 
 ### Design Notes

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -22,6 +22,7 @@ messages in the API response depending on the language preference set in the req
 - Help users understand the information coming from the application backend using a language they understand better
 - To allow FOLIO platform to be used by users across the world 
 - To create a tremendous opportunity for growth that we can never could have achieved within just one country.
+- To Promote consistency and make it easier for tools and translators when handling translation files
 
 ### In Scope Requirements/Use cases
 - Return localized messages based on the value passed in the accept-language header

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -36,7 +36,7 @@ messages in the API response depending on the language preference set in the req
 * Message Value - Refers to the string that is fetched using a message key lookup for a given locale
 * Translation file - Contains Message key and values for a given locale
 * Static Messages - Refers to the messages values stored in the translation file
-* Dynamic Messages - ???
+* Dynamic Messages - Messages stored in the database that requires translation 
 * Message Format - Refers to the standard used for formatting the message values in the translation file
 
 ### In Scope Requirements/Use cases
@@ -70,13 +70,15 @@ messages in the API response depending on the language preference set in the req
   * JavaScript, nodejs - json
   * Any other language - Please contact Technical Council for further guidance
 * Translation files MUST be placed under translations/\<Backend Module Name\>, relative to the root of the repo
-* Translation file name should be ll_CC.ext. Here ‘ll’ is an ISO 639 two-letter language code, 
-   and ‘CC’ is an ISO 3166 two-letter country code.
+* Translation file name SHOULD be [language code]_[country code].[extension] 
+  where `language code` is an ISO 639 two-letter language code, `country code` is an ISO 3166 two-letter country code 
+  and `extension` is the appropriate extension for the file format. For example, in `ll_CC.json`, 
+  ‘ll’ is the language code, ‘CC’ country code and `json` is the extension
 #### Translations
 * Translation message keys MUST be a string (alphanumeric characters ONLY)
 * Message Values in the translation file MUST be formatted according to the [ICU](https://icu.unicode.org)  standard
 #### Language/Runtime
-* Developer should follow language/framework specific recommended best practices for loading translation at runtime
+* Module SHOULD use language/framework specific recommended best practices for loading translation at runtime
 
 
 

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -53,9 +53,9 @@ messages in the API response depending on the language preference set in the req
 
 ## Detailed Explanation/Design
 #### API Protocol
-* accept-language header value MUST be in ll-CC format. , where ll is a two-letter language code,
-  and CC is a two-letter country code. Refer to [IETF Language Tag standard](https://en.wikipedia.org/wiki/IETF_language_tag)
-  for additional details
+* **accept-language** header value MUST be in languageCode-regionCode format, -regionCode is an optional part of the value.
+  * **languageCode** is a two-letter language code from [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1) (2002) or a three-letter code from [ISO 639-2](https://en.wikipedia.org/wiki/ISO_639-2) (1998), [ISO 639-3](https://en.wikipedia.org/wiki/ISO_639-3) (2007) or ISO 639-5 (2008), or registered through the BCP 47 process and composed of five to eight letters;
+  * **regionCode** is a two-letter country code from [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) (written in upper case), or a three-digit code from [UN M.49](https://en.wikipedia.org/wiki/UN_M49) for geographical regions.
 * A module MUST return messages in the language specified in the HTTP "Accept-language" request header
   (see IETF RFC 7231 section 5.3.5).  If the requested language is not available, a module
   MUST return the message in the en language.

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -1,5 +1,5 @@
 
-- Start Date: 03-29-2022
+- Start Date: 2022-03-29
 - RFC PR: 
 - FOLIO Issue: 
 - Submitter : Radhakrishnan Gopalakrishnan (rgopalakrishnan@ebsco.com)

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -24,6 +24,15 @@ messages in the API response depending on the language preference set in the req
 - To create a tremendous opportunity for growth that we can never could have achieved within just one country.
 - To Promote consistency and make it easier for tools and translators when handling translation files
 
+### Terminology
+* Controlled Vocabulary - ???
+* Message Key - Refers to the string that is used in place of a hardcoded message in the code
+* Message Value - Refers to the string that is fetched using a message key lookup for a given locale
+* Translation file - Contains Message key and values for a given locale
+* Static Messages - Refers to the messages values stored in the translation file
+* Dynamic Messages - ???
+* Message Format - Refers to the standard used for formatting the message values in the translation file
+
 ### In Scope Requirements/Use cases
 - Return localized messages based on the value passed in the accept-language header
 - Handle static messages with placeholder(s)
@@ -138,3 +147,4 @@ None that we can think of. The pattern we are adopting is a standard pattern in 
 - Tradeoffs 
 - Can the localization project support translating files that are in different formats. 
   JSON, properties file etc..
+- Terminology Section 

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -25,7 +25,7 @@ messages in the API response depending on the language preference set in the req
 
 ### In Scope Requirements/Use cases
 - Return localized messages based on the value passed in the accept-language header
-- Handle static messages and static messages with placeholders
+- Handle static messages, static messages with placeholders and JSON error response
 
 ### Out of Scope Requirements/Use cases
 - [Plural Syntax](https://wiki.folio.org/display/I18N/How+To+translate+FOLIO#HowTotranslateFOLIO-Pluralsyntax)
@@ -52,9 +52,9 @@ A genuine and thoughtful consideration to risks and drawbacks is essential for a
 
 ## Rationale and Alternatives
 
-Following options were considered. All options except Option 4 involves stripes in some manner.
-Coupling the API backend to a specific front end framework severely limits the usage of FOLIO API to
-only clients that are built using Stripes. 
+**_Following 4 options were considered. All options except Option 4 involves stripes in some manner.
+Coupling the API backend to a specific front end framework limits the usage of FOLIO API to
+only clients that are built using Stripes._**
 
 ### Option 1
 Distribute them over the existing front-end modules:
@@ -67,6 +67,7 @@ ui-requests with translation key ui-requests.mod-circulation.patronHasItemOnLoad
 
 *Cons*
 - Cannot disable a front-end module for a tenant if it hosts a mod-circulation translation key that is needed by another enabled front-end module.
+- Not all originating messages can be mapped to a frontend module 
 
 ### Option 2a
 For each back-end module with translation keys create a dedicated front-end module with language files:
@@ -80,7 +81,8 @@ ui-mod-circulation.patronHasItemOnLoad
 - Any front-end module that uses mod-circulation can require ui-mod-circulation to load the translation files.
 - All mod-circulation translation strings go into a single module.
 *Cons*
-
+- Additional overhead in managing more ui modules
+- Not all originating messages can be mapped to a frontend module
 
 ### Option 2b
 For each back-end interface with translation keys create a dedicated front-end module with language files:
@@ -94,6 +96,8 @@ i18n-circulation.patronHasItemOnLoad
 - Any front-end module that uses the circulation API can require i18n-circulation to load the translation files.
 - All circulation translation strings go into a single module.
 *Cons*
+- Additional overhead in managing more ui modules
+- Not all originating messages can be mapped to a frontend module
 
 ### Option 3
 The back-end module hosts the language files.
@@ -113,6 +117,7 @@ When calling the back-end pass the required locale. The back-end maintains the t
 
 *Pros*
 - Java code and translation files live in the same repository. No work for the front-end.
+- This is a well known pattern in the Java community
 
 *Cons*
 

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -53,24 +53,31 @@ messages in the API response depending on the language preference set in the req
 - Support for [controlled vocabulary](https://issues.folio.org/browse/UXPROD-3148) (runtime data/data coming from DB tables. E.g. Patron Groups for tenants)
 
 ## Detailed Explanation/Design
+#### API Protocol
+* accept-language header value MUST be in ll_CC format. , where ll is a two-letter language code,
+  and CC is a two-letter country code.
+* A module MUST return messages in the language specified in the HTTP "Accept-language" request header
+  (see IETF RFC 7231 section 5.3.5).  If the requested language is not available, a module
+  MUST return the message in the en language.
+* When handling messages with placeholders, replace the placeholders with the actual value on the server side before
+    sending it back to the client
+* Reliance on the lang query string parameter is DEPRECATED and SHOULD be updated to use the "Accept-language" header
+  at the earliest possible development sprint.
+
+#### Translation files
 * Translation file format will depend on the language that is used to develop the module
   * Java, Groovy - properties
   * JavaScript, nodejs - json
   * Any other language - Please contact Technical Council for further guidance
 * Translation files MUST be placed under translations/\<Backend Module Name\>, relative to the root of the repo
-* Translation file name should be ll_CC.ext. Here ‘ll’ is an ISO 639 two-letter language code, and ‘CC’ is an ISO 3166 two-letter country code.
+* Translation file name should be ll_CC.ext. Here ‘ll’ is an ISO 639 two-letter language code, 
+   and ‘CC’ is an ISO 3166 two-letter country code.
+#### Translations
 * Translation message keys MUST be a string (alphanumeric characters ONLY)
+* Message Values in the translation file MUST be formatted according to the [ICU](https://icu.unicode.org)  standard
+#### Language/Runtime
 * Developer should follow language/framework specific recommended best practices for loading translation at runtime
-* When handling messages with placeholders, replace the placeholders with the actual value on the server side before
-  sending it back to the client
-* Reliance on the lang query string parameter is DEPRECATED and SHOULD be updated to use the "Accept-language" header 
-  at the earliest possible development sprint.
-* accept-language header value MUST be in ll_CC format. , where ll is a two-letter language code, 
-  and CC is a two-letter country code.
-* A module MUST return messages in the language specified in the HTTP "Accept-language" request header
-  (see IETF RFC 7231 section 5.3.5).  If the requested language is not available, a module 
-  MUST return the message in the en language.
-* Message Values in the translation file MUST be formatted according to the [ICU](https://icu.unicode.org)  standard 
+
 
 
 ## Rationale and Alternatives

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -60,10 +60,10 @@ Why should we not do this?
 A genuine and thoughtful consideration to risks and drawbacks is essential for a well-rounded proposal. 
 
 ## Rationale and Alternatives
-
-**_Following 4 options were considered. All options except Option 4 involves stripes in some manner.
+<span style="color:green">**_Following 4 options were considered. All options except Option 4 involves stripes in some manner.
 Coupling the API backend to a specific front end framework limits the usage of FOLIO API to
 only clients that are built using Stripes._**
+</span>.
 
 ### Option 1
 Distribute them over the existing front-end modules:

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -36,7 +36,7 @@ messages in the API response depending on the language preference set in the req
 - Usage of [soft hyphen](https://wiki.folio.org/display/I18N/How+To+translate+FOLIO#HowTotranslateFOLIO-Softhyphentobreakwords) to break messages
 - Support customization per tenant
 - Process  for [back porting](https://wiki.folio.org/display/I18N/Backport) API/Backend messages similar to what we have for the front end 
-- Support for controlled vocabulary (runtime data/data coming from DB tables. E.g. Patron Groups for tenants)
+- Support for [controlled vocabulary](https://issues.folio.org/browse/UXPROD-3148) (runtime data/data coming from DB tables. E.g. Patron Groups for tenants)
 
 ## Detailed Explanation/Design
 - Locale specific translations MUST be stored in a properties file

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -53,11 +53,6 @@ messages in the API response depending on the language preference set in the req
   and CC is a two-letter country code.
 - When accept-language header is missing or has an incorrect value, return the message in en_US (or the default locale configured)
 
-## Risks and Drawbacks
-
-Why should we not do this? 
-
-A genuine and thoughtful consideration to risks and drawbacks is essential for a well-rounded proposal. 
 
 ## Rationale and Alternatives
 <span style="color:green">**_Following 4 options were considered. All options except Option 4 involves stripes in some manner.
@@ -129,6 +124,13 @@ When calling the back-end pass the required locale. The back-end maintains the t
 - This is a well known pattern in the Java community
 
 *Cons*
+
+## Risks and Drawbacks
+
+Why should we not do this? 
+
+A genuine and thoughtful consideration to risks and drawbacks is essential for a well-rounded proposal. 
+
 
 ## Unresolved Questions
 - How do we allow tenants to change default locale ?

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -30,13 +30,12 @@ messages in the API response depending on the language preference set in the req
 - To Promote consistency and make it easier for tools and translators when handling translation files
 
 ### Terminology
-* Controlled Vocabulary - ???
 * Base Language - Language on which all other translations are based.
 * Message Key - Refers to the string that is used in place of a hardcoded message in the code
 * Message Value - Refers to the string that is fetched using a message key lookup for a given locale
 * Translation file - Contains Message key and values for a given locale
 * Static Messages - Refers to the messages values stored in the translation file
-* Dynamic Messages - Messages stored in the database that requires translation 
+* Dynamic Messages - Messages stored in the database that requires translation. A.k.a Runtime messages
 * Message Format - Refers to the standard used for formatting the message values in the translation file
 
 ### In Scope Requirements/Use cases
@@ -69,13 +68,15 @@ messages in the API response depending on the language preference set in the req
   * Java, Groovy - properties
   * JavaScript, nodejs - json
   * Any other language - Please contact Technical Council for further guidance
-* Translation files MUST be placed under translations/\<Backend Module Name\>, relative to the root of the repo
-* Translation file name SHOULD be [language code]_[country code].[extension] 
+* Translation files MUST be placed under translations/\<Backend Module Name\>, relative to the root of the repo.
+  The files are being stored under a folder named after the module/repo to avoid having conflicts when using the same
+  message key across multiple backend modules. 
+* Translation file name MUST be [language code]_[country code].[extension] 
   where `language code` is an ISO 639 two-letter language code, `country code` is an ISO 3166 two-letter country code 
-  and `extension` is the appropriate extension for the file format. For example, in `ll_CC.json`, 
+  and `extension` is the appropriate extension for the file format. For example, in `ll-CC.json`, 
   ‘ll’ is the language code, ‘CC’ country code and `json` is the extension
 #### Translations
-* Translation message keys MUST be a string (alphanumeric characters ONLY)
+* Translation message keys MUST be a valid string 
 * Message Values in the translation file MUST be formatted according to the [ICU](https://icu.unicode.org)  standard
 #### Language/Runtime
 * Module SHOULD use language/framework specific recommended best practices for loading translation at runtime
@@ -152,7 +153,7 @@ When calling the back-end pass the required locale. The back-end maintains the t
 - This is a well known pattern in the Java community
 
 *Cons*
-- None
+- We are essentially dealing with translations in multiple locations. Frontend and Backend
 
 ## Risks and Drawbacks
 
@@ -160,11 +161,4 @@ None that we can think of. The pattern we are adopting is a standard pattern in 
 
 
 ## Unresolved Questions
-- Use of ICU for standardizing messages value format in translation files. Impact analysis if were not 
-  to adopt ICU standard
-- Tradeoffs 
-- Can the localization project support translating files that are in different formats. 
-  JSON, properties file etc.
-- Terminology Section 
-- Using - vs. _ in the translation file name
-- Translation file location
+

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -1,7 +1,10 @@
 
 * Start Date: 2022-03-29
 * RFC PR: 
-  * https://github.com/folio-org/rfcs/pull/3
+  * Preliminary Review: https://github.com/folio-org/rfcs/pull/3
+  * Draft Review :
+  * Public Review :
+  * Final Review :
 * FOLIO Issue:
 * Current Status: :no_entry_sign: DRAFT REVIEW :no_entry_sign:
 * Submitter : Radhakrishnan Gopalakrishnan (rgopalakrishnan@ebsco.com)

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -6,7 +6,8 @@
 # Localizing API (Backend) Messages
 
 ## Summary
-
+  The purpose of this RFC is to define an approach that allows API developer to provide
+messages in the API response depending on the language preference set in the request. 
 
 
 ## Motivation

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -19,8 +19,9 @@ messages in the API response depending on the language preference set in the req
 ## Detailed Explanation/Design
 
 ### Terminology
-- Controlled Vocabulary
-- Backport
+- Static Message - This is something you need translate
+- Static Message with placeholder - You can ONLY renew {n} times
+ 
 
 ### In Scope Requirements/Use cases
 - Return localized messages based on the value passed in the accept-language header
@@ -29,9 +30,9 @@ messages in the API response depending on the language preference set in the req
   - validation messages
   - informational messages
   - system error messages
-  - Messages with dynamic content. For E.g Loan CANNOT be renewed more than {n} times
 - Define naming convention to be used for keys
 - [Plural Syntax](https://wiki.folio.org/display/I18N/How+To+translate+FOLIO#HowTotranslateFOLIO-Pluralsyntax)
+- Runtime values that are to be localized (E.g. Patron Groups) 
 
 ### Out of Scope Requirements/Use cases
 - Process for managing (decoupled from lokalise.com) translations

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -57,7 +57,7 @@ messages in the API response depending on the language preference set in the req
 ## Rationale and Alternatives
 <span style="color:green">**_Following 4 options were considered. All options except Option 4 involves stripes in some manner.
 Coupling the API backend to a specific front end framework limits the usage of FOLIO API to
-only clients that are built using Stripes._**
+only clients that are built using Stripes. As a result, we are recommending that we go with Option 4._**
 </span>.
 
 ### Option 1

--- a/text/0000-localizing-api-messages.md
+++ b/text/0000-localizing-api-messages.md
@@ -11,7 +11,10 @@
 
 ## Motivation
 
-Why are we doing this? What use cases does it support? What is the expected outcome? What is the strategic value?
+- Help users understand the information coming from the application backend as they can relate to it  better when it is
+    in a language they understand
+- To allow FOLIO platform to be used by users across the world 
+- To create a tremendous opportunity for growth that we can never could have achieved within just one country.
 
 ## Detailed Explanation/Design
 


### PR DESCRIPTION
The purpose of this RFC is to define an approach that allows API developer to provide messages in the API response depending on the language preference set in the request.