### PR TITLE
[PRELIMINARY REVIEW] Java 17

### DIFF
--- a/text/0000-java-17.md
+++ b/text/0000-java-17.md
@@ -65,6 +65,10 @@ flower releases reach their end of life (end of official support period).
 The migration of Spring based modules has shown that it's little effort and low risk:
 https://wiki.folio.org/display/TC/JDK+17+and+Java+17
 
+Note that Spring based modules migrated to Java 17, Spring Boot 3 and
+Spring Framework 2.7 at the same time:
+https://wiki.folio.org/display/FOLIJET/Migration+to+Spring+Boot+v3.0.0+How+to
+
 The drawback of this RFC is that it's late, however, a proposal for Orchid
 posted on #tech-council channel in August 2022 got no TC approval.
 


### PR DESCRIPTION
This RFC is an substantial change to the FOLIO platform because dropping Java 11 is

* the removal of a feature that is already part of a FOLIO release,
* a change that requires the coordination between multiple FOLIO components or services,
* and Java 17 has been a new feature which might be considered redundant to existing feature Java 11.

This matches the criteria of
https://github.com/folio-org/rfcs#when-you-need-to-follow-this-process
making this RFC mandatory.

At this time there is no other workflow in place that might allow to change https://wiki.folio.org/display/TC/Officially+Supported+Technologies