### PR TITLE
PRELIMINARY REVIEW: 0004 Date-time values must comply with IETF RFC-3339

### DIFF
--- a/text/0004-iso-8601.md
+++ b/text/0004-iso-8601.md
@@ -20,7 +20,7 @@ Code that validates date-time values must do so in accordance with [IETF RFC-333
 
 Date-time values at rest must be fully compliant with [IETF RFC-3339 Section 5.6](https://www.rfc-editor.org/rfc/rfc3339.html#section-5.6).
 
-Code that handles date-time values must respect all aspects such values, including but not limited to their `time-offset` attributes. For example, an API that retrieves entries in a given date-time range must return the same results given any of the following arguments:
+Code that handles date-time values must respect all aspects of such values, including but not limited to their `time-offset` attributes. For example, an API that retrieves entries in a given date-time range must return the same results given any of the following arguments:
 
 * `2023-10-05T12:51:12.000-04:00` and `2023-10-06T12:51:12.000-04:00`
 * `2023-10-05T16:51:12.000Z` and `2023-10-06T16:51:12.000Z`
@@ -38,7 +38,7 @@ Some APIs may accept date-time values that lack a time-offset attribute. For suc
 
 ## Rationale and Alternatives
 
-This RFC aims to increase the clarity and precision of our guidance while at the same time bring it into compliance with IETF RFC-3339.
+This RFC aims to increase the clarity and precision of our guidance while at the same time bringing it into compliance with IETF RFC-3339.
 
 ## Unresolved Questions
 

--- a/text/0004-iso-8601.md
+++ b/text/0004-iso-8601.md
@@ -1,6 +1,12 @@
 - Start Date: 2023-10-06
-- RFC PR:
-- FOLIO Issue:
+- Contributors:
+  - [Zak Burke](zburke@ebsco.com)
+- RFC PRs:
+  - DRAFT REVIEW: https://github.com/folio-org/rfcs/pull/13
+  - PRELIMINARY REVIEW: TBD
+  - PUBLIC REVIEW: TBD
+  - FINAL REVIEW: TBD
+- Outcome: <!-- Leave this blank. Will eventually be either ACCEPTED or REJECTED -->
 
 # Date-time values must comply with IETF RFC-3339
 

--- a/text/0004-iso-8601.md
+++ b/text/0004-iso-8601.md
@@ -20,11 +20,11 @@ Code that validates date-time values must do so in accordance with [IETF RFC-333
 
 Date-time values at rest must be fully compliant with [IETF RFC-3339 Section 5.6](https://www.rfc-editor.org/rfc/rfc3339.html#section-5.6).
 
-Code that handles date-time values must respect all aspects such values, including but not limited to their `time-offset` attributes. For example, an API that retrieves entries in a given date-time range (inclusive) must return the same results given any of the following arguments:
+Code that handles date-time values must respect all aspects such values, including but not limited to their `time-offset` attributes. For example, an API that retrieves entries in a given date-time range must return the same results given any of the following arguments:
 
-* `2023-10-05T12:51:12.000-0400` and `2023-10-06T12:51:12.000-0400`
+* `2023-10-05T12:51:12.000-04:00` and `2023-10-06T12:51:12.000-04:00`
 * `2023-10-05T16:51:12.000Z` and `2023-10-06T16:51:12.000Z`
-* `2023-10-05T11:51:12.000-0500` and `2023-10-06T18:51:12.000+0200`
+* `2023-10-05T11:51:12.000-05:00` and `2023-10-06T18:51:12.000+02:00`
 
 ### Related Jiras
 

--- a/text/0004-iso-8601.md
+++ b/text/0004-iso-8601.md
@@ -35,6 +35,7 @@ Code that handles date-time values must respect all aspects of such values, incl
 ### Related Jiras
 
 * [MODAUD-172](https://issues.folio.org/browse/MODAUD-172)
+* [UICIRCLOG-125](https://issues.folio.org/browse/UICIRCLOG-125)
 
 ## Risks and Drawbacks
 

--- a/text/0004-iso-8601.md
+++ b/text/0004-iso-8601.md
@@ -1,0 +1,45 @@
+- Start Date: 2023-10-06
+- RFC PR:
+- FOLIO Issue:
+
+# Date-time values must comply with IETF RFC-3339
+
+## Summary
+
+* Validation of date-time values must assert compliance with IETF RFC-3339.
+* Date-time values in storage must be compliant with IETF RFC-3339 Section 5.6.
+* APIs must respect date-time values when retrieving a range of values by date-time in a query.
+
+## Motivation
+
+Compliance with [IETF RFC-3339](https://www.rfc-editor.org/rfc/rfc3339.html) as stated in our ["Working with dates and times" documentation](https://dev.folio.org/guides/dates-and-times/).
+
+## Detailed Explanation/Design
+
+Code that validates date-time values must do so in accordance with [IETF RFC-3339 Section 5.6](https://www.rfc-editor.org/rfc/rfc3339.html#section-5.6).
+
+Date-time values at rest must be fully compliant with [IETF RFC-3339 Section 5.6](https://www.rfc-editor.org/rfc/rfc3339.html#section-5.6).
+
+Code that handles date-time values must respect all aspects such values, including but not limited to their `time-offset` attributes. For example, an API that retrieves entries in a given date-time range (inclusive) must return the same results given any of the following arguments:
+
+* `2023-10-05T12:51:12.000-0400` and `2023-10-06T12:51:12.000-0400`
+* `2023-10-05T16:51:12.000Z` and `2023-10-06T16:51:12.000Z`
+* `2023-10-05T11:51:12.000-0500` and `2023-10-06T18:51:12.000+0200`
+
+### Related Jiras
+
+* [MODAUD-172](https://issues.folio.org/browse/MODAUD-172)
+
+## Risks and Drawbacks
+
+Existing documentation states that, "The APIs assume UTC on input, and store and return timestamps in UTC". Thus, APIs may assume date-time values without a `time-offset` attributes are UTC, which may be incorrect given that ISO-8601 states that [when no UTC offset is provided, "the time is assumed to be in local time"](https://en.wikipedia.org/wiki/ISO_8601#Local_time_(unqualified)).
+
+Some APIs may accept date-time values that lack a time-offset attribute. For such APIs, this will be a breaking change.
+
+## Rationale and Alternatives
+
+This RFC aims to increase the clarity and precision of our guidance while at the same time bring it into compliance with IETF RFC-3339.
+
+## Unresolved Questions
+
+None. Long live IETF RFC-3339.

--- a/text/0004-iso-8601.md
+++ b/text/0004-iso-8601.md
@@ -6,7 +6,7 @@
   - PRELIMINARY REVIEW: TBD
   - PUBLIC REVIEW: TBD
   - FINAL REVIEW: TBD
-- Outcome: <!-- Leave this blank. Will eventually be either ACCEPTED or REJECTED -->
+- Outcome: REJECTED
 
 # Date-time values must comply with IETF RFC-3339
 


### PR DESCRIPTION
* Validation of date-time values must assert compliance with IETF RFC-3339.
* Date-time values in storage must be compliant with IETF RFC-3339 Section 5.6.
* APIs must respect date-time values when retrieving a range of values by date-time in a query.