### PR TITLE
Update outcome field in metadata

### DIFF
--- a/text/0005-application-formalization.md
+++ b/text/0005-application-formalization.md
@@ -7,7 +7,7 @@
   * DRAFT REFINEMENT: https://github.com/folio-org/rfcs/pull/22
   * PUBLIC REVIEW: https://github.com/folio-org/rfcs/pull/29
   * FINAL REVIEW: https://github.com/folio-org/rfcs/pull/34
-* Outcome: <!-- Leave this blank. Will eventually be either ACCEPTED or REJECTED -->
+* Outcome: ACCEPTED
 
 # Application Formalization
 


### PR DESCRIPTION
I forgot the specify the outcome in the RFC metadata for 0005 Application Formalization.  This PR fixes the metadata (outcome:  ACCEPTED)