### PR TITLE
Remove DRAFT REVIEW metadata

### DIFF
--- a/0000-template.md
+++ b/0000-template.md
@@ -4,7 +4,6 @@
   - [FirstName LastName](EmailAddress)
 - RFC PRs: 
   - PRELIMINARY REVIEW: TBD
-  - DRAFT REVIEW: TBD
   - PUBLIC REVIEW: TBD
   - FINAL REVIEW: TBD
 - Outcome: (Leave this blank.  Will eventually be either ACCEPTED or REJECTED)


### PR DESCRIPTION
During a post-rfc retrospective, the TC has agreed to remove the DRAFT REFINEMENT (aka DRAFT REVIEW) stage.  See https://folio-org.atlassian.net/wiki/spaces/TC/pages/323321857/2024-07-10+RFC+Retro+Board+Review+Meeting+notes and https://easyretro.io/publicboard/dY8fCRqguiSDP3wtvSLhNzlULdM2/1cf104bb-6aa4-4eb3-a878-0f9f1e235436 for details.

This PR makes the necessary adjustments to the RFC template by removing the metadata field for DRAFT REVIEW.