### PR TITLE
Cancel 0008 bounded contexts

### DIFF
--- a/text/0008-bounded-contexts.md
+++ b/text/0008-bounded-contexts.md
@@ -12,10 +12,11 @@
 # Bounded contexts
 
 ## Summary
-It is proposed that the boundary of the microservices, and thus the bounded context, be extended beyond the module. The new bounded context would be found at the Application level. Thus, any of the backend modules in the Application would be able to directly access the storage layer.
+The term bounded context often appears in discussions about decomposing a monolithic system into multiple microservices.  Instead of all services sharing a single database, the system is partitioned into several bounded contexts, each with it's own database, data models, etc.  In Folio's case, we're working the other direction.  When the project started, it was decided that each module should have their own database, and cross-module database access must be avoided.  Coupling this with another practice the project has followed, separating business logic and storage modules, we wind up with suboptimal service/storage interactions.  It is proposed that we introduce the concept of bounded contexts, which would align with Application boundaries.  Any of the backend modules in a given Application would be able to directly access the storage layer.
 
 ## Scope
-* Cross-module database access 
+* Cross-module database access
+  * Data "ownership" and read vs write access
 * Ensuring data integrity
 * Example use cases
 * Practical considerations for how this will work

--- a/text/0008-bounded-contexts.md
+++ b/text/0008-bounded-contexts.md
@@ -3,8 +3,8 @@
   * [Craig McNally](cmcnally@ebsco.com)
   * [Vince Bareau](vbareau@ebsco.com)
 * RFC PRs:
-  * DRAFT REVIEW: TBD
-  * PRELIMINARY REVIEW: TBD
+  * PRELIMINARY REVIEW: https://github.com/folio-org/rfcs/pull/17
+  * DRAFT REFINEMENT: TBD
   * PUBLIC REVIEW: TBD
   * FINAL REVIEW: TBD
 * Outcome: 

--- a/text/0008-bounded-contexts.md
+++ b/text/0008-bounded-contexts.md
@@ -3,7 +3,7 @@
   * [Craig McNally](cmcnally@ebsco.com)
   * [Vince Bareau](vbareau@ebsco.com)
 * RFC PRs:
-  * PRELIMINARY REVIEW: https://github.com/folio-org/rfcs/pull/17
+  * PRELIMINARY REVIEW: https://github.com/folio-org/rfcs/pull/20
   * DRAFT REFINEMENT: TBD
   * PUBLIC REVIEW: TBD
   * FINAL REVIEW: TBD

--- a/text/0008-bounded-contexts.md
+++ b/text/0008-bounded-contexts.md
@@ -1,0 +1,25 @@
+* Start Date: 11/13/2023
+* Contributors:
+  * [Craig McNally](cmcnally@ebsco.com)
+  * [Vince Bareau](vbareau@ebsco.com)
+* RFC PRs:
+  * DRAFT REVIEW: TBD
+  * PRELIMINARY REVIEW: TBD
+  * PUBLIC REVIEW: TBD
+  * FINAL REVIEW: TBD
+* Outcome: 
+
+# Bounded contexts
+
+## Summary
+It is proposed that the boundary of the microservices, and thus the bounded context, be extended beyond the module. The new bounded context would be found at the Application level. Thus, any of the backend modules in the Application would be able to directly access the storage layer.
+
+## Scope
+* Cross-module database access 
+* Ensuring data integrity
+* Example use cases
+* Practical considerations for how this will work
+
+## Timing
+* Fourth in the sequence.
+* RFC Submission: ~Early-Mid January '24

--- a/text/0008-bounded-contexts.md
+++ b/text/0008-bounded-contexts.md
@@ -20,6 +20,7 @@ The term bounded context often appears in discussions about decomposing a monoli
 * Ensuring data integrity
 * Example use cases
 * Practical considerations for how this will work
+* Backward compatibility with Folio instances not adopting Applications
 * Access to any databases outside of the bounded context / Application is ***out of scope***
 
 ## Timing

--- a/text/0008-bounded-contexts.md
+++ b/text/0008-bounded-contexts.md
@@ -20,6 +20,7 @@ The term bounded context often appears in discussions about decomposing a monoli
 * Ensuring data integrity
 * Example use cases
 * Practical considerations for how this will work
+* Access to any databases outside of the bounded context / Application is ***out of scope***
 
 ## Timing
 * Fourth in the sequence.

--- a/text/0008-bounded-contexts.md
+++ b/text/0008-bounded-contexts.md
@@ -7,7 +7,7 @@
   * DRAFT REFINEMENT: TBD
   * PUBLIC REVIEW: TBD
   * FINAL REVIEW: TBD
-* Outcome: 
+* Outcome: Cancelled - The Technical Council has decided that the best path forward is to close these smaller, focused RFCs in favor of a single, wider-scoped RFC.
 
 # Bounded contexts
 


### PR DESCRIPTION
The Technical Council has decided that the best path forward is to close these smaller, focused RFCs in favor of a single, wider-scoped RFC.

* Set the outcome of the RFC to cancelled, with explanation
* Merge the branch to the mainline branch for visibility.